### PR TITLE
Adopt config:best-practices, enable pre-commit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "config:best-practices"
+  ],
+  "pre-commit": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
## Summary

Renovate extends `config:best-practices` (instead of `config:recommended`) and the pre-commit manager is opted in.

Closes #116.

## Verification

- `npx --yes --package renovate -- renovate-config-validator` reports `Config validated successfully`.