### PR TITLE
Rewrite README with current workflow and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # collection-json
 
 [![Hackage](https://img.shields.io/hackage/v/collection-json.svg)](https://hackage.haskell.org/package/collection-json)
-[![Hackage Dependencies](https://img.shields.io/hackage-deps/v/collection-json.svg)](https://packdeps.haskellers.com/feed?needle=collection-json)
 [![CI](https://github.com/alunduil/collection-json.hs/actions/workflows/ci.yml/badge.svg)](https://github.com/alunduil/collection-json.hs/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/alunduil/collection-json.hs.svg)](LICENSE)
 [![GHC](https://img.shields.io/badge/GHC-9.6%20%7C%209.8%20%7C%209.10%20%7C%209.12-blue.svg)](https://www.haskell.org/ghc/)

--- a/README.md
+++ b/README.md
@@ -1,39 +1,73 @@
-# Description
+# collection-json
 
-[Collection+JSON] Tools
+[![Hackage](https://img.shields.io/hackage/v/collection-json.svg)](https://hackage.haskell.org/package/collection-json)
+[![Hackage Dependencies](https://img.shields.io/hackage-deps/v/collection-json.svg)](https://packdeps.haskellers.com/feed?needle=collection-json)
+[![CI](https://github.com/alunduil/collection-json.hs/actions/workflows/ci.yml/badge.svg)](https://github.com/alunduil/collection-json.hs/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/alunduil/collection-json.hs.svg)](LICENSE)
+[![GHC](https://img.shields.io/badge/GHC-9.6%20%7C%209.8%20%7C%209.10%20%7C%209.12-blue.svg)](https://www.haskell.org/ghc/)
 
-Types, classes, and functions for using the
-[Collection+JSON—Hypermedia Type][Collection+JSON] in [Haskell].
+[Collection+JSON—Hypermedia Type][Collection+JSON] tools for [Haskell].
+
+`collection-json` lets you encode, decode, and manipulate
+`application/vnd.collection+json` documents.  The library exposes a single
+module, `Data.CollectionJSON`, with `aeson` `ToJSON`/`FromJSON` instances for
+each type defined by the spec — `Collection`, `Item`, `Link`, `Query`,
+`Template`, `Datum`, and `Error`.
+
+## Install
+
+Add `collection-json` to the `build-depends` of your package, or install it
+directly:
+
+```sh
+cabal install --lib collection-json
+```
+
+## Usage
+
+Roundtrip a minimal collection through `aeson`:
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import Data.Aeson (decode, encode)
+import qualified Data.ByteString.Lazy.Char8 as BL
+import Data.CollectionJSON (Collection (..))
+import Data.Maybe (fromJust)
+import Network.URI (parseURI)
+
+main :: IO ()
+main = do
+  let href = fromJust (parseURI "http://example.com/friends/")
+      c    = Collection "1.0" href [] [] [] Nothing Nothing
+
+  BL.putStrLn (encode c)
+  -- {"collection":{"href":"http://example.com/friends/","version":"1.0"}}
+
+  print (decode (encode c) :: Maybe Collection)
+  -- Just (Collection {cVersion = "1.0", cHref = ..., ...})
+```
+
+Full API reference on [Hackage].  The Collection+JSON specification is at
+<http://amundsen.com/media-types/collection/>.
+
+## Contributing
+
+Report bugs and feature requests on the [issue tracker].
+
+For changes, fork the repository, branch from `main`, and open a pull request
+against `main`.  PRs are squash-merged.  If you'd like attribution, add yourself
+to the [`COPYRIGHT`](COPYRIGHT) file in the same PR.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).
 
 I am providing code in the repository to you under an open source license.
 Because this is my personal repository, the license you receive to my code is
 from me and not my employer (Facebook).
 
-# Getting Started
-
-Documentation is available on [Hackage] and information about
-`application/vnd.collection+json` can be found at
-<http://amundsen.com/media-types/collection/>.
-
-# Reporting Issues
-
-Any issues discovered should be recorded on [github][issues].  If you believe
-you've found an error or have a suggestion for a new feature; please, ensure
-that it is reported.
-
-If you would like to contribute a fix or new feature; please, submit a pull
-request.  This project follows [git flow] and utilizes [travis] to automatically
-check pull requests before a manual review.
-
-# Contributors
-
-The `COPYRIGHT` file contains a list of contributors with their respective
-copyrights and other information.  If you submit a pull request and would like
-attribution; please, add yourself to the `COPYRIGHT` file.
-
 [Collection+JSON]: http://amundsen.com/media-types/collection/
-[git flow]: http://nvie.com/posts/a-successful-git-branching-model/
 [Hackage]: https://hackage.haskell.org/package/collection-json
 [Haskell]: https://www.haskell.org/
-[issues]: https://github.com/alunduil/collection-json.hs/issues
-[travis]: https://travis-ci.org/alunduil/collection-json.hs
+[issue tracker]: https://github.com/alunduil/collection-json.hs/issues


### PR DESCRIPTION
## Summary

README now leads with the project name, surfaces Hackage / CI / license / GHC badges, ships a runnable encode/decode roundtrip, and describes the trunk-based contribution flow the milestone is landing on (squash PRs to `main`, attribution via `COPYRIGHT`).

Closes #106.

## Gotchas

- **Hackage-deps badge dropped** despite being in #106's scope. shields.io retired the `hackage-deps` endpoint — the URL now renders the literal text "retired badge". No working replacement exists, so the badge is omitted entirely. Four badges instead of five.
- The CI badge URL points at `actions/workflows/ci.yml/badge.svg`, which only renders once #114 lands. Issue body explicitly noted this dependency; the badge URL is stable, so the badge starts working as soon as the workflow exists.
- `develop` → `main` rename is tracked in #82 (also in this milestone). README now refers only to `main`; `source-repository head { branch: develop }` in `collection-json.cabal` is left for #113 to flip in the same commit that cuts 1.3.1.4.
- GHC version badge is a static shields.io label hand-set to 9.6 / 9.8 / 9.10 / 9.12 — the matrix #114 will adopt per #113. If #113 lands a different `tested-with`, this badge needs the same edit.

## Verification

- Confirmed no references to `develop`, `master`, `git flow`, or `travis` remain.
- README passes `markdownlint-cli2` v0.22.1 (markdownlint v0.40.0) on default config — 0 errors.
- Confirmed shields.io's `hackage-deps` endpoint renders "retired badge" (live fetch).
- The runnable example mirrors the test-suite's `encode (Collection "1.0" eURI [] [] [] Nothing Nothing)` invocation byte-for-byte (test/Data/CollectionJSONSpec.hs:78), so the construction and serialised output are already covered by `cabal test`.
- Did not compile-check the example locally (no GHC/cabal in this environment) — relying on CI once #114 lands.