### PR TITLE
Modernise cabal file and set verified bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to the [Haskell Package Versioning Policy
 
 - Compatible with `aeson` 2.2, `base` 4.22, and `network-uri-json` 0.4
   (no API changes).
+- Modernised `collection-json.cabal`: `cabal-version: 3.0`, `common
+  warnings`/`common language` stanzas, `tested-with` set to GHC 9.6 /
+  9.8 / 9.10 / 9.12, and dependency bounds tightened to honest ranges
+  for that matrix. Test-suite no longer recompiles `src/`; depends on
+  the `collection-json` library directly.
 
 ## [1.3.1.3] - 2019-02-21
 

--- a/collection-json.cabal
+++ b/collection-json.cabal
@@ -1,3 +1,4 @@
+cabal-version:       3.0
 name:                collection-json
 version:             1.3.1.3
 synopsis:            Collection+JSON—Hypermedia Type Tools
@@ -15,80 +16,82 @@ maintainer:          alunduil@alunduil.com
 copyright:           (c) 2017 Alex Brandt
 category:            Data
 build-type:          Simple
-cabal-version:       >= 1.18
-tested-with:         GHC >= 7.6 && < 8.2.1 || > 8.2.1 && < 9.0
-
-extra-source-files:
-    COPYRIGHT
-  , LICENSE
-  , README.md
-  , Setup.hs
+tested-with:         GHC == 9.6.*
+                   , GHC == 9.8.*
+                   , GHC == 9.10.*
+                   , GHC == 9.12.*
 
 extra-doc-files:
     CHANGELOG.md
+  , COPYRIGHT
+  , README.md
+
+extra-source-files:
+    Setup.hs
 
 source-repository head
   type:     git
   location: https://github.com/alunduil/collection-json.hs
   branch:   develop
 
-library
+common warnings
+  ghc-options: -Wall
+               -Wcompat
+               -Widentities
+               -Wincomplete-record-updates
+               -Wincomplete-uni-patterns
+               -Wpartial-fields
+               -Wredundant-constraints
+
+common language
   default-language: Haskell2010
 
-  ghc-options: -Wall -fwarn-tabs -fwarn-monomorphism-restriction
-               -fwarn-unused-do-bind
+library
+  import:           warnings, language
 
-  hs-source-dirs:
-      src
+  hs-source-dirs:   src
 
   exposed-modules:
       Data.CollectionJSON
 
-  other-modules:
-
   build-depends:
-      aeson >=0.8 && <2.3
-    , base >=4.6 && <4.23
-    , network-uri      == 2.6.*
-    , network-uri-json >=0.1 && <0.5
-    , text             == 1.2.*
+      aeson            >= 2.0  && < 2.3
+    , base             >= 4.18 && < 4.22
+    , network-uri      >= 2.6  && < 2.7
+    , network-uri-json >= 0.4  && < 0.5
+    , text             >= 2.0  && < 2.2
 
   other-extensions:
       OverloadedStrings
     , RecordWildCards
 
 test-suite collection-json-tests
-  default-language: Haskell2010
+  import:           warnings, language
   type:             exitcode-stdio-1.0
   main-is:          Spec.hs
 
-  ghc-options: -Wall -fwarn-tabs -fwarn-monomorphism-restriction
-               -fwarn-unused-do-bind
-
-  hs-source-dirs:
-      src
-    , test
+  hs-source-dirs:   test
 
   other-modules:
-      Data.CollectionJSON
-    , Data.CollectionJSON.Arbitrary
+      Data.CollectionJSON.Arbitrary
     , Data.CollectionJSONSpec
 
   build-tool-depends:
-      hspec-discover:hspec-discover >= 2.4 && < 2.8
+      hspec-discover:hspec-discover >= 2.10 && < 2.12
 
   build-depends:
-      aeson >=0.8 && <2.3
-    , base >=4.6 && <4.23
-    , bytestring           == 0.10.*
-    , hspec >=2.4 && <2.12
-    , network-arbitrary >=0.3 && <1.1
-    , network-uri          == 2.6.*
-    , network-uri-json >=0.1 && <0.5
-    , QuickCheck >=2.9 && <2.19
-    , quickcheck-instances == 0.3.*
-    , test-invariant       == 0.4.*
-    , text                 == 1.2.*
+      aeson                >= 2.0  && < 2.3
+    , base                 >= 4.18 && < 4.22
+    , bytestring           >= 0.11 && < 0.13
+    , collection-json
+    , hspec                >= 2.10 && < 2.12
+    , network-arbitrary    >= 1.0  && < 1.1
+    , network-uri          >= 2.6  && < 2.7
+    , network-uri-json     >= 0.4  && < 0.5
+    , QuickCheck           >= 2.14 && < 2.19
+    , quickcheck-instances >= 0.3  && < 0.4
+    , test-invariant       >= 0.4  && < 0.5
+    , text                 >= 2.0  && < 2.2
 
   other-extensions:
       OverloadedStrings

--- a/src/Data/CollectionJSON.hs
+++ b/src/Data/CollectionJSON.hs
@@ -15,7 +15,6 @@ Full documentation for @application/vnd.collection+json@ can be found at
 module Data.CollectionJSON where
 
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), object, withObject, (.!=), (.:), (.:?), (.=))
-import Data.Functor ((<$>))
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import Network.URI (URI, nullURI)

--- a/test/Data/CollectionJSON/Arbitrary.hs
+++ b/test/Data/CollectionJSON/Arbitrary.hs
@@ -11,7 +11,6 @@ Arbitrary instances for "Data.CollectionJSON".
 -}
 module Data.CollectionJSON.Arbitrary where
 
-import Control.Applicative ((<$>), (<*>))
 import Data.Text (pack)
 import Network.URI.Arbitrary ()
 import Test.QuickCheck (Arbitrary (arbitrary, shrink))


### PR DESCRIPTION
## Summary

Restructures `collection-json.cabal` to current conventions and sets honest bounds aligned with the GHC 9.6/9.8/9.10/9.12 matrix that #114's CI targets. Test-suite stops recompiling `src/` and depends on the library directly.

## Changes

- `cabal-version: 3.0`; `common warnings` / `common language` stanzas imported by both library and test-suite.
- Modern warning flags: `-Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints` (legacy `-fwarn-*` spellings dropped).
- `tested-with: GHC == 9.6.*, GHC == 9.8.*, GHC == 9.10.*, GHC == 9.12.*`.
- Bounds set per issue spec: `aeson 2.0/2.3`, `base 4.18/4.22`, `bytestring 0.11/0.13`, `network-uri 2.6/2.7`, `network-uri-json 0.4/0.5`, `text 2.0/2.2`, plus aligned test-suite deps (`hspec 2.10/2.12`, `network-arbitrary 1.0/1.1`, `QuickCheck 2.14/2.19`, `quickcheck-instances 0.3/0.4`, `test-invariant 0.4/0.5`).
- Test-suite drops `src` from `hs-source-dirs`, depends on `collection-json`, and removes `Data.CollectionJSON` from `other-modules`.
- `COPYRIGHT` and `README.md` join `CHANGELOG.md` in `extra-doc-files`.
- Dropped redundant `Data.Functor ((<$>))` and `Control.Applicative ((<$>), (<*>))` imports — both have been in Prelude since base 4.8.
- CHANGELOG entry under Unreleased.

`source-repository head { branch: develop }` is unchanged; flipping to `main` is gated on #82.

## Gotchas

- **`cabal build` is not yet green on the matrix.** `network-uri-json-0.4.0.0` on Hackage still ships `base < 4.14` and `text == 1.2.*`, so the solver rejects modern base/text. Resolving needs a Hackage revision or new release of `network-uri-json` (alunduil-owned) — out of scope here. The bounds declared in this PR are the *target* honest bounds; #114's CI matrix will keep them honest once the upstream release lands.
- `tested-with` versions track #114; adjust if that workflow lands different versions.

## Verification

- `cabal check` — no errors or warnings.
- `cabal sdist` — produces a valid tarball; manifest includes `CHANGELOG.md`, `COPYRIGHT`, `LICENSE`, `README.md`, `Setup.hs`, library + test sources.
- `pre-commit run` — fourmolu and hlint pass on changed files.
- Build/test verification on the four-GHC matrix is deferred to #114's workflow.

Closes #113.