### PR TITLE
Audit test suite against Collection+JSON spec

### DIFF
--- a/test/Data/CollectionJSONSpec.hs
+++ b/test/Data/CollectionJSONSpec.hs
@@ -39,6 +39,15 @@ spec =
           it "'Collection' errors on \"{}\"" $
             isNothing (decode "{}" :: Maybe Collection)
 
+        describe "required keys" $
+          context "decode fails when a spec-required key is absent" $
+            do
+              it "'Link' without \"href\"" $ isNothing (decode "{\"rel\":\"item\"}" :: Maybe Link)
+              it "'Link' without \"rel\"" $ isNothing (decode "{\"href\":\"http://example.com\"}" :: Maybe Link)
+              it "'Query' without \"href\"" $ isNothing (decode "{\"rel\":\"item\"}" :: Maybe Query)
+              it "'Query' without \"rel\"" $ isNothing (decode "{\"href\":\"http://example.com\"}" :: Maybe Query)
+              it "'Datum' without \"name\"" $ isNothing (decode "{}" :: Maybe Datum)
+
         describe "properties" $
           context "fromJust . decode . encode == id" $
             do
@@ -84,6 +93,10 @@ spec =
 
                 it "Collection" $
                   encode (Collection "1.0" eURI [] [] [] Nothing Nothing) `shouldBe` mCollection
+
+            context "decode supplies defaults for absent optional keys" $
+              it "Collection \"version\" defaults to 1.0" $
+                fmap cVersion (decode "{\"collection\":{}}" :: Maybe Collection) `shouldBe` Just "1.0"
  where
   mCollection = "{\"collection\":{\"href\":\"http://example.com\",\"version\":\"1.0\"}}" :: BL.ByteString
   mLink = "{\"href\":\"http://example.com\",\"rel\":\"item\"}" :: BL.ByteString


### PR DESCRIPTION
## Summary

Reconciles the hspec suite with the Collection+JSON format spec
(<http://amundsen.com/media-types/collection/format/>). The audit found
the decoders already correct but two spec rules unexercised; this adds
those tests. Spec divergences (where behaviour, not coverage, differs)
are split to #146.

## Spec-vs-suite checklist

Already covered: `collection` required (errors on `{}`), `template`
`data` defaulting, round-trip + minimal encode/decode for all seven
types, optional-fields-absent-when-empty on encode.

Gaps closed here (behaviour was correct, just untested):

- [x] Spec-REQUIRED keys enforced on decode — `Link`/`Query` without
      `href` or `rel`, `Datum` without `name` all fail.
- [x] `collection` `version` defaults to `"1.0"` when absent.

Divergences — behaviour/API decisions, not test gaps → **#146**:

- `Datum` `value` accepts only STRING; NUMBER/boolean fail to decode
  though the spec permits them (priority — breaking fix).
- `Link` `render` not constrained to `image`/`link`.
- `collection` `version` accepted as any string, not validated as `1.0`.
- `Item` `href` required, though spec marks it SHOULD.

Not applicable: "at most one collection/template/error object" is JSON
object semantics, not something the decoders can violate.

## Verification

- `cabal test -w ghc-9.10.3 --enable-tests` — 30 examples, 0 failures.
- `fourmolu --mode check` and `hlint` clean on the test module.
- Verified the value-type divergence in `cabal repl`: `value:5` and
  `value:true` decode to `Nothing`, `value:"x"` and `value:null` to
  `Just`.

Closes #129.