### PR TITLE
ci: report test coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,5 +143,6 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.report.outputs.report }}
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,49 @@ jobs:
       - name: Haddock
         working-directory: sdist-build
         run: cabal haddock all --allow-newer=network-arbitrary:base,network-arbitrary:QuickCheck
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up GHC
+        uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553 # v2.11.0
+        with:
+          ghc-version: "9.14"
+          cabal-version: latest
+
+      - name: Update Hackage index
+        run: cabal update
+
+      # Coverage builds from the working tree, not the sdist the build
+      # job uses: the instrumented .mix/.tix paths then map straight onto
+      # the repo's src/ layout that Codecov reports against. allow-newer
+      # mirrors the build job's network-arbitrary stopgap.
+      - name: Configure with coverage
+        run: cabal configure --enable-tests --enable-coverage --allow-newer=network-arbitrary:base,network-arbitrary:QuickCheck
+
+      - name: Build
+        run: cabal build all
+
+      - name: Test
+        run: cabal test all --test-show-details=direct
+
+      # excludes drops the test components so the report measures the
+      # library module alone.
+      - name: Generate coverage report
+        id: report
+        uses: 8c6794b6/hpc-codecov-action@f943f40733e5390825b12d72165cad991e44340c # v4.3.0
+        with:
+          target: cabal:collection-json-tests
+          excludes: Main,Paths_collection_json,Data.CollectionJSONSpec,Data.CollectionJSON.Arbitrary
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ${{ steps.report.outputs.report }}
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Hackage](https://img.shields.io/hackage/v/collection-json.svg)](https://hackage.haskell.org/package/collection-json)
 [![CI](https://github.com/alunduil/collection-json.hs/actions/workflows/ci.yml/badge.svg)](https://github.com/alunduil/collection-json.hs/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/alunduil/collection-json.hs/branch/main/graph/badge.svg)](https://codecov.io/gh/alunduil/collection-json.hs)
 [![License](https://img.shields.io/github/license/alunduil/collection-json.hs.svg)](LICENSE)
 [![GHC](https://img.shields.io/badge/GHC-9.10%20%7C%209.12%20%7C%209.14-blue.svg)](https://www.haskell.org/ghc/)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,8 @@
-# Coverage is reported, not gated: status checks post the delta on PRs
-# but never fail the build. The hspec suite's job is to encode the spec,
-# not to chase a coverage number.
 coverage:
   status:
     project:
       default:
-        informational: true
+        threshold: 1%
     patch:
       default:
-        informational: true
+        threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+# Coverage is reported, not gated: status checks post the delta on PRs
+# but never fail the build. The hspec suite's job is to encode the spec,
+# not to chase a coverage number.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary

The agent guide promises the hspec suite encodes the Collection+JSON spec, but that promise is only as strong as the suite's coverage of it — and we don't measure today. This wires HPC coverage into CI and uploads it to Codecov so PRs surface coverage deltas and gaps in the encoding become visible before they reach Hackage.

A new `coverage` job builds the library and test suite with `--enable-coverage`, converts the `.tix` output to a Codecov report with `hpc-codecov`, and uploads it on every push to `main` and every PR. `codecov.yml` gates project/patch coverage at a 1% threshold (matching the `woodland-generators` house pattern), and the README gains a Codecov badge.

Unblocked by #114 (GHA migration), which landed via #135.

## Setup note

Uploading requires a `CODECOV_TOKEN` repo secret — it's now configured. Tokenless upload only works for fork PRs; a same-repo branch PR into a protected `main` is rejected with `Token required because branch is protected`. The Codecov GitHub App handles posting checks/comments back to GitHub, but does not cover the upload token, and tokens are per-repo.

## Gotchas

- **Builds from the working tree, not the sdist.** The matrix `build` job builds from the unpacked sdist to validate published bounds; the coverage job builds from the checkout instead so the instrumented module paths map straight onto `src/` the way Codecov reports against. Same `allow-newer=network-arbitrary:base,network-arbitrary:QuickCheck` stopgap as the build job.
- **Single GHC (9.14), Ubuntu only.** Line coverage of the library is GHC-independent; running the full matrix would just upload duplicate reports.
- **`hpc-codecov` `excludes`** drops the test components (`Main`, `Paths_collection_json`, the spec and arbitrary modules) so the report measures the library module alone — no `ignore` list needed in `codecov.yml`.

## Verification

I could not build locally — the only installed GHC is 9.6.7 (base 4.18) and the package requires base ≥ 4.20 (GHC 9.10+), with no Nix on this host. CI is the verification surface, and it's green end to end on GHC 9.14: Configure / Build / Test / Generate coverage report / Upload all pass, and Codecov posted both `codecov/project` and `codecov/patch` checks on this PR — the baseline run the issue asks for. All acceptance criteria met: coverage uploaded on push/PR, status checks present, README badge resolves, baseline recorded.

Closes #128