### PR TITLE
Add markdownlint to pre-commit

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,13 @@
+{
+  // markdownlint ruleset. Read by markdownlint-cli2 (the pre-commit hook)
+  // and by editor integrations. Default ruleset with two deviations.
+  "default": true,
+
+  // Prose isn't hard-wrapped to a fixed column here, and the vendored
+  // Contributor Covenant ships one paragraph per line.
+  "MD013": false,
+
+  // Keep a Changelog repeats Added/Changed/Fixed headings under every
+  // release; siblings_only flags duplicates only within the same parent.
+  "MD024": { "siblings_only": true }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ repos:
       - id: check-yaml
         exclude: '^\.github/workflows/'
 
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
+    hooks:
+      - id: markdownlint-cli2
+
   # fourmolu and hlint are installed in the dev environment (or in CI by the
   # Pre-commit workflow) and invoked from PATH. Renovate's pre-commit manager
   # only tracks third-party hooks with a `rev:` field, so the pinned versions

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at alunduil@alunduil.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <alunduil@alunduil.com>. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,19 +12,19 @@ Prerequisites: GHC and `cabal-install`. The supported GHC range is
 declared in [`tested-with`](collection-json.cabal); CI runs the
 matrix on every PR.
 
-```
+```sh
 cabal build
 cabal test
 ```
 
 ## Formatting and linting
 
-Formatting (Fourmolu) and linting (HLint) run through
-[pre-commit](https://pre-commit.com). The `Pre-commit` workflow runs
-the same hooks on every push and PR; merges are blocked until they
-pass.
+Formatting (Fourmolu), Haskell linting (HLint), and Markdown linting
+(markdownlint-cli2) run through [pre-commit](https://pre-commit.com).
+The `Pre-commit` workflow runs the same hooks on every push and PR;
+merges are blocked until they pass.
 
-```
+```sh
 pre-commit install            # install the git hook (one-off)
 pre-commit run --all-files    # run all hooks against the repo
 pre-commit autoupdate         # bump third-party hook revs


### PR DESCRIPTION
## Summary

Closes #124. Lints Markdown through the `markdownlint-cli2` pre-commit
hook instead of a standalone CI step. The issue (filed before the repo
adopted pre-commit) asked for a dedicated job in `ci.yml`; the repo now
runs all linting — Fourmolu, HLint — through `.pre-commit-config.yaml`
and the `Pre-commit` workflow, so Markdown linting joins that
mechanism. No new CI job, and the existing workflow already fails any
PR that introduces a violation.

The default ruleset reported 30 violations against the current tree, so
this lands a clean baseline alongside the hook.

## Gotchas

- **Scope diverges from the issue text** on two counts, both confirmed
  before implementing: pre-commit hook over a `ci.yml` step, and the
  "baseline is clean" claim in the issue was based on README alone —
  CHANGELOG/CONTRIBUTING/CODE_OF_CONDUCT have since landed and tripped
  the default rules.
- **MD013 (line-length) is disabled globally.** Prose here isn't
  hard-wrapped to a fixed column, and the vendored Contributor Covenant
  ships one paragraph per line.
- **MD024 uses `siblings_only`** so Keep a Changelog's repeated
  `Added`/`Changed` headings under each release don't trip the
  duplicate-heading rule.
- Config lives in `.markdownlint.jsonc` (not the cli2-specific name) so
  editor integrations read it too. Renovate's pre-commit manager tracks
  the pinned hook `rev`.
- No CHANGELOG/version bump — tooling-only change, left for the release
  cut.

## Verification

- `npx markdownlint-cli2 "**/*.md" "#dist*"` → `0 error(s)` (was 30).
- `pre-commit run markdownlint-cli2 --all-files` → Passed.
- Content fixes: two CONTRIBUTING shell blocks tagged `sh` (MD040), CoC
  contact email wrapped as an autolink (MD034).

🤖 Generated with [Claude Code](https://claude.com/claude-code)